### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/CustomizableMigration.php
+++ b/src/CustomizableMigration.php
@@ -81,7 +81,7 @@ abstract class CustomizableMigration extends Migration
     /**
      * Create a new morph relation.
      */
-    protected function createMorph(Blueprint $table, string $name, string $indexName = null): void
+    protected function createMorph(Blueprint $table, string $name, ?string $indexName = null): void
     {
         if ($this->morphCalled) {
             throw new BadMethodCallException('Using multiple customizable morph calls is unsupported.');
@@ -102,7 +102,7 @@ abstract class CustomizableMigration extends Migration
     /**
      * Create a new nullable morph relation.
      */
-    protected function createNullableMorph(Blueprint $table, string $name, string $indexName = null): void
+    protected function createNullableMorph(Blueprint $table, string $name, ?string $indexName = null): void
     {
         if ($this->morphCalled) {
             throw new BadMethodCallException('Using multiple customizable morph calls is unsupported.');
@@ -127,7 +127,7 @@ abstract class CustomizableMigration extends Migration
      * @param  string|null  $indexName
      * @return $this
      */
-    public function morph(string $type, string $indexName = null): static
+    public function morph(string $type, ?string $indexName = null): static
     {
         $this->morphType = $type;
         $this->morphIndexName = $indexName;


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Laragear\MetaModel\CustomizableMigration::createMorph(): Implicitly marking parameter $indexName as nullable is deprecated, the explicit nullable type must be used instead in ./src/CustomizableMigration.php on line 84
PHP Deprecated:  Laragear\MetaModel\CustomizableMigration::createNullableMorph(): Implicitly marking parameter $indexName as nullable is deprecated, the explicit nullable type must be used instead in ./src/CustomizableMigration.php on line 105
PHP Deprecated:  Laragear\MetaModel\CustomizableMigration::morph(): Implicitly marking parameter $indexName as nullable is deprecated, the explicit nullable type must be used instead in ./src/CustomizableMigration.php on line 130
```